### PR TITLE
Fix --name-only options

### DIFF
--- a/lib/tasks/task.git-lastlog.js
+++ b/lib/tasks/task.git-lastlog.js
@@ -17,7 +17,7 @@ class GitLastLogTask {
 
 		const tableOpts = {
 			head : [
-				chalk.cyan( self.nameOnly ? "Directory" : "Name" ),
+				chalk.cyan( self.nameOnly ? "Name" : "Directory" ),
 				chalk.cyan( "Log" ),
 				chalk.cyan( "When" )
 			],
@@ -60,7 +60,7 @@ class GitLastLogTask {
 				}
 
 				self.table.push( [
-					colorize( self.nameOnly ? repository.path : repository.path ),
+					colorize( self.nameOnly ? repository.name : repository.path ),
 					colorize( logEntry.header ),
 					colorize( logEntry.date.relative )
 				] );

--- a/lib/tasks/task.git-status.js
+++ b/lib/tasks/task.git-status.js
@@ -19,7 +19,7 @@ class GitStatusTask {
 
 		const tableOpts = {
 			head  : [
-				chalk.cyan( self.nameOnly ? "Directory" : "Name" ),
+				chalk.cyan( self.nameOnly ? "Name" : "Directory" ),
 				chalk.cyan( "Branch" ),
 				chalk.cyan( self.small ? "A" : "Ahead" ),
 				chalk.cyan( self.small ? "B" : "Behind" ),
@@ -78,7 +78,7 @@ class GitStatusTask {
 				}
 
 				self.table.push( [
-					colorize( self.nameOnly ? repository.path : repository.path ),
+					colorize( self.nameOnly ? repository.name : repository.path ),
 					colorize( status.current ),
 					colorize( status.ahead ),
 					colorize( status.behind ),


### PR DESCRIPTION
First column of `lastlog` and `status` output always displayed repository path regardless of `nameOnly` option. Moreover, the first column header was wrong.